### PR TITLE
Pipeline: publish jar content files as a pipeline artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Desktop.ini
 /its/src/test/projects/ConsoleApp1/ConsoleApp1/bin
 /omnisharp-plugin/.vs
 /omnisharp-dotnet/.omnisharp
+/omnisharp-dotnet/JarContentFiles

--- a/omnisharp-dotnet/azure-pipelines-dotnet.yml
+++ b/omnisharp-dotnet/azure-pipelines-dotnet.yml
@@ -65,5 +65,11 @@ steps:
     arguments: '-p:CollectCoverage=true -p:CoverletOutput=TestResults/ -p:CoverletOutputFormat=opencover'
     nobuild: true
     testRunTitle: '.NET unit tests'
-    
+
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish the jar content files as a pipeline artifact'
+  inputs:
+    path: omnisharp-dotnet/JarContentFiles 
+    artifact: DotNetJarContentFiles
+      
 - task: SonarQubeAnalyze@4

--- a/omnisharp-dotnet/src/SonarLint.OmniSharp.Plugin/SonarLint.OmniSharp.Plugin.csproj
+++ b/omnisharp-dotnet/src/SonarLint.OmniSharp.Plugin/SonarLint.OmniSharp.Plugin.csproj
@@ -11,5 +11,27 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
   </ItemGroup>
+  
+  
+  <!-- ********************************************** -->
+  <!-- Packaging files to be included in the Java jar -->
+  <!-- ********************************************** -->
+    <!-- Add any files that should be included in the Java plugin to the item group @"FilesToIncludeInJar".
+         The files will be copied to the directory "JarContentFiles". -->
+  <ItemGroup>
+    <FilesToIncludeInJar Include="$(TargetDir)$(TargetFileName)" />
+  </ItemGroup>
+  
+  <Target Name="CopyFilesToJarContentFolder" AfterTargets="Build" Inputs="$(TargetDir)$(TargetFileName)" Outputs="$(JarContentFolder)$(TargetFileName)">
+
+    <PropertyGroup>
+      <JarContentFolder>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\..\JarContentFiles\))</JarContentFolder>
+    </PropertyGroup>
+
+    <Message Importance="high" Text="Copying plugin files to $(JarContentFolder)" />
+    <RemoveDir Directories="$(JarContentFolder)" />
+    
+    <Copy OverwriteReadOnlyFiles="true" SourceFiles="@(FilesToIncludeInJar)" DestinationFolder="$(JarContentFolder)" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
Amended build and pipeline to publish the files that need to be included in the jar to a folder called JarContentFiles.

The pipeline publishes the contents of the folder as an artifact that can be downloaded after the pipeline has finished.