### PR TITLE
Tidy up project output folder

### DIFF
--- a/omnisharp-dotnet/Directory.Build.props
+++ b/omnisharp-dotnet/Directory.Build.props
@@ -19,10 +19,10 @@
   <Import Project="build\DownloadOmniSharp.targets"/>
 
   <ItemGroup Label="OmniSharp assemblies">
-    <Reference Include="$(OmniSharpUnzippedDir)\omnisharp\OmniSharp.Abstractions.dll" />
-    <Reference Include="$(OmniSharpUnzippedDir)\omnisharp\OmniSharp.Shared.dll" />
-    <Reference Include="$(OmniSharpUnzippedDir)\omnisharp\OmniSharp.Roslyn.dll" />
-    <Reference Include="$(OmniSharpUnzippedDir)\omnisharp\OmniSharp.Roslyn.CSharp.dll" />
+    <Reference Include="$(OmniSharpUnzippedDir)\omnisharp\OmniSharp.Abstractions.dll" Private="$(CopyOmniSharpToOutput)" />
+    <Reference Include="$(OmniSharpUnzippedDir)\omnisharp\OmniSharp.Shared.dll" Private="$(CopyOmniSharpToOutput)" />
+    <Reference Include="$(OmniSharpUnzippedDir)\omnisharp\OmniSharp.Roslyn.dll" Private="$(CopyOmniSharpToOutput)" />
+    <Reference Include="$(OmniSharpUnzippedDir)\omnisharp\OmniSharp.Roslyn.CSharp.dll" Private="$(CopyOmniSharpToOutput)" />
   </ItemGroup>
 
 </Project>

--- a/omnisharp-dotnet/src/SonarLint.OmniSharp.Plugin.UnitTests/SonarLint.OmniSharp.Plugin.UnitTests.csproj
+++ b/omnisharp-dotnet/src/SonarLint.OmniSharp.Plugin.UnitTests/SonarLint.OmniSharp.Plugin.UnitTests.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>.netcoreapp3.1</TargetFramework>
+    
+    <!-- We need the OmniSharp assemblies to execute the tests-->
+    <CopyOmniSharpToOutput>true</CopyOmniSharpToOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/omnisharp-dotnet/src/SonarLint.OmniSharp.Plugin/SonarLint.OmniSharp.Plugin.csproj
+++ b/omnisharp-dotnet/src/SonarLint.OmniSharp.Plugin/SonarLint.OmniSharp.Plugin.csproj
@@ -2,6 +2,9 @@
   
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+
+    <!-- We don't want to ship the OmniSharp assemblies -->
+    <CopyOmniSharpToOutput>false</CopyOmniSharpToOutput>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Marking the OmniSharp files as "private" stops them and their dependencies from being copied to the product output folder (we need them at build time, but don't want to ship them).
We do need them to be copied to the test output folder since the tests require them at execution time.