### PR TITLE
Bump OmniSharp to version v.1.37.11

### DIFF
--- a/omnisharp-dotnet/Directory.Build.props
+++ b/omnisharp-dotnet/Directory.Build.props
@@ -27,7 +27,7 @@
     <!-- TODO: this version needs to be kept in sync with
       1) the version in the POM for the ITs
       2) the version in the POM of the SonarLint.IntelliJ repo -->
-    <OmniSharpVersion>v1.37.9</OmniSharpVersion>
+    <OmniSharpVersion>v1.37.11</OmniSharpVersion>
 
     <OmniSharpLocalDownloadDir>$(MSBuildThisFileDirectory).omnisharp\$(OmniSharpVersion)</OmniSharpLocalDownloadDir>
     <OmniSharpUnzippedDir>$(OmniSharpLocalDownloadDir)\unzipped</OmniSharpUnzippedDir>

--- a/omnisharp-dotnet/src/SonarLint.OmniSharp.Plugin.UnitTests/packages.lock.json
+++ b/omnisharp-dotnet/src/SonarLint.OmniSharp.Plugin.UnitTests/packages.lock.json
@@ -96,8 +96,8 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "3.10.0",
-        "contentHash": "Htsk5pJmKjTgUwAP5oyuIODX/b6Zl4RD0tpM62NEncxne/LiQvP50j9g8h+qFtp4lS4AmAYTVPBbXgBuC5zcQA==",
+        "resolved": "3.11.0-1.final",
+        "contentHash": "xy3KiEPrQ9MMdfOVPXeAVmfL5sIvH2LLjvCmv8MDwIoXpG6ui6NGMi6HJ00ONHOwdzpUnMMWpE1+D1SFaqCHVQ==",
         "dependencies": {
           "Microsoft.CodeAnalysis.Analyzers": "3.3.2",
           "System.Collections.Immutable": "5.0.0",
@@ -110,31 +110,31 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Transitive",
-        "resolved": "3.10.0",
-        "contentHash": "GM83V29l0zsOLReyxpFs32Ujss3wkrVbWFTVjGANXxceycWmi7aLBNL4TQ3r3ZiG4m2b+/LIqwIVkDvZpjOnuw==",
+        "resolved": "3.11.0-1.final",
+        "contentHash": "zLntfcMggZ5Muk0jK23EbfCZVl22dcXS9nqpKb/1CT0Pyf83bnoc6G/O7Wki9dNllxNJTlOHUEb2rYpf4J4Cag==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[3.10.0]"
+          "Microsoft.CodeAnalysis.Common": "[3.11.0-1.final]"
         }
       },
       "Microsoft.CodeAnalysis.CSharp.Workspaces": {
         "type": "Transitive",
-        "resolved": "3.10.0",
-        "contentHash": "8BamkN75WMDUMdgSEp19eFEasQG7B/qmMRrQ73kWLG+t03jHEi9xDEtK3T5AME3StXsQ1/4Cw1wlx9g2nmsk3w==",
+        "resolved": "3.11.0-1.final",
+        "contentHash": "0yCKczHHoPZHXK1DQ7ZnhoEHKFppHD8+u5SI+rcCdZLOw+qum/RD3cIlx9jlJt9ptl7MruGB4FGDf4/I+3u2kw==",
         "dependencies": {
           "Humanizer.Core": "2.2.0",
-          "Microsoft.CodeAnalysis.CSharp": "[3.10.0]",
-          "Microsoft.CodeAnalysis.Common": "[3.10.0]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[3.10.0]"
+          "Microsoft.CodeAnalysis.CSharp": "[3.11.0-1.final]",
+          "Microsoft.CodeAnalysis.Common": "[3.11.0-1.final]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[3.11.0-1.final]"
         }
       },
       "Microsoft.CodeAnalysis.Workspaces.Common": {
         "type": "Transitive",
-        "resolved": "3.10.0",
-        "contentHash": "ls5J6dkaa8WdgqX1cJxTJQfdMZ4BvAUUXiHBapJZ5X/3G6P0Y/1rPUKJbC2NKNTtI/PQXNfaylH0V5J06lY2nw==",
+        "resolved": "3.11.0-1.final",
+        "contentHash": "2kJYwtksfoRNtub+hbwWOqL6gsWxlX0hS2LKMxQV6s1mYKqyvRKI9vcYY5F7uFFxL/ZUOSQZ2OFc7iNjnN+UrA==",
         "dependencies": {
           "Humanizer.Core": "2.2.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
-          "Microsoft.CodeAnalysis.Common": "[3.10.0]",
+          "Microsoft.CodeAnalysis.Common": "[3.11.0-1.final]",
           "System.Composition": "1.0.31",
           "System.IO.Pipelines": "5.0.1"
         }
@@ -1376,7 +1376,7 @@
       "sonarlint.omnisharp.plugin": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "3.10.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "3.11.0-1.final",
           "Microsoft.Extensions.Logging.Abstractions": "3.1.12",
           "Microsoft.Extensions.Options": "3.1.12",
           "Newtonsoft.Json": "12.0.3",

--- a/omnisharp-dotnet/src/SonarLint.OmniSharp.Plugin/SonarLint.OmniSharp.Plugin.csproj
+++ b/omnisharp-dotnet/src/SonarLint.OmniSharp.Plugin/SonarLint.OmniSharp.Plugin.csproj
@@ -12,7 +12,7 @@
          Referencing a different version of NewtonSoft.Json doesn't seem to cause a problem,
          but we're targeting the same version to be on the safe side.
     --> 
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0-1.final" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />

--- a/omnisharp-dotnet/src/SonarLint.OmniSharp.Plugin/packages.lock.json
+++ b/omnisharp-dotnet/src/SonarLint.OmniSharp.Plugin/packages.lock.json
@@ -4,14 +4,14 @@
     ".NETStandard,Version=v2.0": {
       "Microsoft.CodeAnalysis.CSharp.Workspaces": {
         "type": "Direct",
-        "requested": "[3.10.0, )",
-        "resolved": "3.10.0",
-        "contentHash": "8BamkN75WMDUMdgSEp19eFEasQG7B/qmMRrQ73kWLG+t03jHEi9xDEtK3T5AME3StXsQ1/4Cw1wlx9g2nmsk3w==",
+        "requested": "[3.11.0-1.final, )",
+        "resolved": "3.11.0-1.final",
+        "contentHash": "0yCKczHHoPZHXK1DQ7ZnhoEHKFppHD8+u5SI+rcCdZLOw+qum/RD3cIlx9jlJt9ptl7MruGB4FGDf4/I+3u2kw==",
         "dependencies": {
           "Humanizer.Core": "2.2.0",
-          "Microsoft.CodeAnalysis.CSharp": "[3.10.0]",
-          "Microsoft.CodeAnalysis.Common": "[3.10.0]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[3.10.0]"
+          "Microsoft.CodeAnalysis.CSharp": "[3.11.0-1.final]",
+          "Microsoft.CodeAnalysis.Common": "[3.11.0-1.final]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[3.11.0-1.final]"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -75,8 +75,8 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "3.10.0",
-        "contentHash": "Htsk5pJmKjTgUwAP5oyuIODX/b6Zl4RD0tpM62NEncxne/LiQvP50j9g8h+qFtp4lS4AmAYTVPBbXgBuC5zcQA==",
+        "resolved": "3.11.0-1.final",
+        "contentHash": "xy3KiEPrQ9MMdfOVPXeAVmfL5sIvH2LLjvCmv8MDwIoXpG6ui6NGMi6HJ00ONHOwdzpUnMMWpE1+D1SFaqCHVQ==",
         "dependencies": {
           "Microsoft.CodeAnalysis.Analyzers": "3.3.2",
           "System.Collections.Immutable": "5.0.0",
@@ -89,20 +89,20 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Transitive",
-        "resolved": "3.10.0",
-        "contentHash": "GM83V29l0zsOLReyxpFs32Ujss3wkrVbWFTVjGANXxceycWmi7aLBNL4TQ3r3ZiG4m2b+/LIqwIVkDvZpjOnuw==",
+        "resolved": "3.11.0-1.final",
+        "contentHash": "zLntfcMggZ5Muk0jK23EbfCZVl22dcXS9nqpKb/1CT0Pyf83bnoc6G/O7Wki9dNllxNJTlOHUEb2rYpf4J4Cag==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[3.10.0]"
+          "Microsoft.CodeAnalysis.Common": "[3.11.0-1.final]"
         }
       },
       "Microsoft.CodeAnalysis.Workspaces.Common": {
         "type": "Transitive",
-        "resolved": "3.10.0",
-        "contentHash": "ls5J6dkaa8WdgqX1cJxTJQfdMZ4BvAUUXiHBapJZ5X/3G6P0Y/1rPUKJbC2NKNTtI/PQXNfaylH0V5J06lY2nw==",
+        "resolved": "3.11.0-1.final",
+        "contentHash": "2kJYwtksfoRNtub+hbwWOqL6gsWxlX0hS2LKMxQV6s1mYKqyvRKI9vcYY5F7uFFxL/ZUOSQZ2OFc7iNjnN+UrA==",
         "dependencies": {
           "Humanizer.Core": "2.2.0",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
-          "Microsoft.CodeAnalysis.Common": "[3.10.0]",
+          "Microsoft.CodeAnalysis.Common": "[3.11.0-1.final]",
           "System.Composition": "1.0.31",
           "System.IO.Pipelines": "5.0.1"
         }


### PR DESCRIPTION
Note: this requires using a prerelease Roslyn version

Relates to #56