### PR TITLE
BUILD-2951 Adapt sonarlint-omnisharp (replace set-output deprecated)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,10 @@ jobs:
         id: get_version
         run: |
           IFS=. read major minor patch build <<< "${{ github.event.release.tag_name }}"
-          echo ::set-output name=build::"${build}"
+          echo "build=${build}" >> "$GITHUB_OUTPUT"
       - name: Create local repository directory
         id: local_repo
-        run: echo ::set-output name=dir::"$(mktemp -d repo.XXXXXXXX)"
+        run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> "$GITHUB_OUTPUT"
       - name: Download Artifacts
         uses: SonarSource/gh-action_release/download-build@v4
         with:


### PR DESCRIPTION
# BUILD-2951 Adapt sonarlint-omnisharp (replace set-output deprecated)

## Changes
* replace set-output with the [recommended way by GitHub](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
   That way it can work after 31st of May