### PR TITLE
SLOMNI-26 Update missed copyright date

### DIFF
--- a/omnisharp-dotnet/src/Services.UnitTests/Rules/RulesToAdditionalTextConverterTests.cs
+++ b/omnisharp-dotnet/src/Services.UnitTests/Rules/RulesToAdditionalTextConverterTests.cs
@@ -24,7 +24,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarLint.OmniSharp.DotNet.Services.Rules;
 using SonarLint.OmniSharp.DotNet.Services.Rules.SonarLintXml;
-using SonarLint.VisualStudio.Core.CSharpVB;
 
 namespace SonarLint.OmniSharp.DotNet.Services.UnitTests.Rules
 {

--- a/omnisharp-dotnet/src/Services.UnitTests/Rules/SonarLintXml/RulesToSonarLintConfigurationConverterTests.cs
+++ b/omnisharp-dotnet/src/Services.UnitTests/Rules/SonarLintXml/RulesToSonarLintConfigurationConverterTests.cs
@@ -24,7 +24,6 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarLint.OmniSharp.DotNet.Services.Rules;
 using SonarLint.OmniSharp.DotNet.Services.Rules.SonarLintXml;
-using SonarLint.VisualStudio.Core.CSharpVB;
 
 namespace SonarLint.OmniSharp.DotNet.Services.UnitTests.Rules.SonarLintXml
 {

--- a/omnisharp-dotnet/src/Services.UnitTests/Rules/SonarLintXml/SonarLintConfigurationSerializerTests.cs
+++ b/omnisharp-dotnet/src/Services.UnitTests/Rules/SonarLintXml/SonarLintConfigurationSerializerTests.cs
@@ -24,7 +24,6 @@ using System.Xml.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarLint.OmniSharp.DotNet.Services.Rules.SonarLintXml;
-using SonarLint.VisualStudio.Core.CSharpVB;
 
 namespace SonarLint.OmniSharp.DotNet.Services.UnitTests.Rules.SonarLintXml
 {

--- a/omnisharp-dotnet/src/Services/Rules/SonarLintXml/RulesToSonarLintConfigurationConverter.cs
+++ b/omnisharp-dotnet/src/Services/Rules/SonarLintXml/RulesToSonarLintConfigurationConverter.cs
@@ -20,7 +20,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using SonarLint.VisualStudio.Core.CSharpVB;
 
 namespace SonarLint.OmniSharp.DotNet.Services.Rules.SonarLintXml
 {

--- a/omnisharp-dotnet/src/Services/Rules/SonarLintXml/SonarLintConfiguration.cs
+++ b/omnisharp-dotnet/src/Services/Rules/SonarLintXml/SonarLintConfiguration.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * SonarLint for Visual Studio
+ * SonarOmnisharp
  * Copyright (C) 2021-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
@@ -24,7 +24,7 @@ using System.Xml.Serialization;
 // Copied unchanged from SLVS
 // The file must be kept in line with the format that sonar-dotnet analyzers expect: 
 // https://github.com/SonarSource/sonar-dotnet/blob/1711a5f773013925e079d11e32bf0a3f592a6706/analyzers/src/SonarAnalyzer.Common/Common/RuleLoader.cs#L30
-namespace SonarLint.VisualStudio.Core.CSharpVB
+namespace SonarLint.OmniSharp.DotNet.Services.Rules.SonarLintXml
 {
     /* XML-serializable classes to create a SonarLint.xml file.
         Example:

--- a/omnisharp-dotnet/src/Services/Rules/SonarLintXml/SonarLintConfiguration.cs
+++ b/omnisharp-dotnet/src/Services/Rules/SonarLintXml/SonarLintConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * SonarLint for Visual Studio
- * Copyright (C) 2016-2021 SonarSource SA
+ * Copyright (C) 2021-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/omnisharp-dotnet/src/Services/Rules/SonarLintXml/SonarLintConfigurationSerializer.cs
+++ b/omnisharp-dotnet/src/Services/Rules/SonarLintXml/SonarLintConfigurationSerializer.cs
@@ -22,7 +22,6 @@ using System.IO;
 using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
-using SonarLint.VisualStudio.Core.CSharpVB;
 
 namespace SonarLint.OmniSharp.DotNet.Services.Rules.SonarLintXml
 {


### PR DESCRIPTION
[SLOMNI-26](https://sonarsource.atlassian.net/browse/SLOMNI-26)

* Update the copyright date on `SonarLintConfiguration.cs` header which was missed during `Happy new year 2024`
* CaYC: Move the file to the correct namespace based on its location

[SLOMNI-26]: https://sonarsource.atlassian.net/browse/SLOMNI-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ