### PR TITLE
SLOMNI-129 Auto-select a compatible .NET SDK when SDK 10+ is installed

### DIFF
--- a/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/DotNetSdkPathResolver.java
+++ b/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/DotNetSdkPathResolver.java
@@ -1,0 +1,97 @@
+/*
+ * SonarOmnisharp
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.omnisharp;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+public final class DotNetSdkPathResolver {
+
+  private static final Pattern SDK_VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+(?:\\.\\d+)?(?:[-\\w.]*)?");
+
+  private DotNetSdkPathResolver() {
+    // utility class
+  }
+
+  public static final class SdkConfiguration {
+    private final Path path;
+    private final String version;
+
+    public SdkConfiguration(Path path, String version) {
+      this.path = path;
+      this.version = version;
+    }
+
+    public Path path() {
+      return path;
+    }
+
+    public String version() {
+      return version;
+    }
+  }
+
+  public static Optional<SdkConfiguration> fromPathHint(@Nullable Path pathHint) {
+    if (pathHint == null) {
+      return Optional.empty();
+    }
+    Path normalized = pathHint.normalize();
+    Path current = normalized;
+    while (current != null) {
+      Path parent = current.getParent();
+      if (parent != null && "sdk".equalsIgnoreCase(parent.getFileName().toString())) {
+        String version = current.getFileName().toString();
+        if (isSdkVersion(version)) {
+          return Optional.of(new SdkConfiguration(current, version));
+        }
+      }
+      current = parent;
+    }
+    String lastSegment = normalized.getFileName().toString();
+    if (isSdkVersion(lastSegment)) {
+      return Optional.of(new SdkConfiguration(normalized, lastSegment));
+    }
+    return Optional.empty();
+  }
+
+  public static int parseMajorVersion(String version) {
+    int dotIndex = version.indexOf('.');
+    if (dotIndex <= 0) {
+      return -1;
+    }
+    try {
+      return Integer.parseInt(version.substring(0, dotIndex));
+    } catch (NumberFormatException e) {
+      return -1;
+    }
+  }
+
+  public static boolean isCompatibleSdkVersion(String version) {
+    int major = parseMajorVersion(version);
+    return major > 0 && major <= 9;
+  }
+
+  private static boolean isSdkVersion(String value) {
+    return SDK_VERSION_PATTERN.matcher(value).matches();
+  }
+
+}

--- a/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/DotNetSdkSelector.java
+++ b/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/DotNetSdkSelector.java
@@ -1,0 +1,205 @@
+/*
+ * SonarOmnisharp
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.omnisharp;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import org.sonar.api.utils.System2;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonarsource.api.sonarlint.SonarLintSide;
+
+@SonarLintSide(lifespan = SonarLintSide.MODULE)
+public class DotNetSdkSelector {
+
+  private static final Logger LOG = Loggers.get(DotNetSdkSelector.class);
+  private static final Pattern LIST_SDKS_PATTERN = Pattern.compile("^(\\S+)\\s+\\[(.+)]$");
+  private static final int PROCESS_TIMEOUT_SEC = 30;
+
+  private final System2 system2;
+
+  public DotNetSdkSelector(System2 system2) {
+    this.system2 = system2;
+  }
+
+  @Nullable
+  public Path selectCompatibleSdkPath(Path projectBaseDir, @Nullable Path sdkPathHint, @Nullable Path dotnetCliPath) {
+    var compatibleHint = DotNetSdkPathResolver.fromPathHint(sdkPathHint)
+      .filter(sdk -> DotNetSdkPathResolver.isCompatibleSdkVersion(sdk.version()))
+      .map(DotNetSdkPathResolver.SdkConfiguration::path)
+      .orElse(null);
+    if (compatibleHint != null) {
+      return compatibleHint;
+    }
+
+    if (sdkPathHint != null) {
+      DotNetSdkPathResolver.fromPathHint(sdkPathHint).ifPresent(sdk ->
+        LOG.info("Ignoring incompatible .NET SDK hint {} (OmniSharp 1.39.x does not support SDK {}+)",
+          sdk.path(), DotNetSdkPathResolver.parseMajorVersion(sdk.version()) + 1));
+    }
+
+    var globalJsonVersion = readGlobalJsonSdkVersion(projectBaseDir);
+    var installedSdks = listInstalledSdks(dotnetCliPath).stream()
+      .filter(sdk -> DotNetSdkPathResolver.isCompatibleSdkVersion(sdk.version()))
+      .collect(Collectors.toList());
+
+    if (installedSdks.isEmpty()) {
+      LOG.warn("No .NET SDK compatible with OmniSharp found on the machine");
+      return null;
+    }
+
+    var selected = globalJsonVersion
+      .flatMap(requested -> installedSdks.stream()
+        .filter(sdk -> sdk.version().startsWith(requested) || requested.startsWith(sdk.version()))
+        .max(Comparator.comparing(SdkInfo::version, DotNetSdkSelector::compareSdkVersions)))
+      .orElseGet(() -> installedSdks.stream().max(Comparator.comparing(SdkInfo::version, DotNetSdkSelector::compareSdkVersions)).orElseThrow());
+
+    LOG.info("Selected .NET SDK {} for OmniSharp analysis", selected.path());
+    return selected.path();
+  }
+
+  private static Optional<String> readGlobalJsonSdkVersion(Path projectBaseDir) {
+    var current = projectBaseDir.toAbsolutePath().normalize();
+    while (current != null) {
+      var globalJson = current.resolve("global.json");
+      if (Files.isRegularFile(globalJson)) {
+        try {
+          var json = JsonParser.parseString(Files.readString(globalJson, StandardCharsets.UTF_8)).getAsJsonObject();
+          if (json.has("sdk") && json.get("sdk").isJsonObject()) {
+            JsonObject sdk = json.getAsJsonObject("sdk");
+            if (sdk.has("version")) {
+              return Optional.of(sdk.get("version").getAsString());
+            }
+          }
+        } catch (Exception e) {
+          LOG.debug("Unable to read global.json at {}", globalJson, e);
+        }
+        return Optional.empty();
+      }
+      current = current.getParent();
+    }
+    return Optional.empty();
+  }
+
+  private List<SdkInfo> listInstalledSdks(@Nullable Path dotnetCliPath) {
+    var dotnetExecutable = resolveDotnetExecutable(dotnetCliPath);
+    var command = new ArrayList<String>();
+    command.add(dotnetExecutable);
+    command.add("--list-sdks");
+
+    try {
+      var process = new ProcessBuilder(command).redirectErrorStream(true).start();
+      if (!process.waitFor(PROCESS_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        LOG.warn("Timed out while listing installed .NET SDKs");
+        return List.of();
+      }
+      if (process.exitValue() != 0) {
+        LOG.warn("Failed to list installed .NET SDKs (exit code {})", process.exitValue());
+        return List.of();
+      }
+      try (var reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+        return reader.lines()
+          .map(String::trim)
+          .filter(line -> !line.isEmpty())
+          .map(DotNetSdkSelector::parseListSdksLine)
+          .flatMap(Optional::stream)
+          .collect(Collectors.toList());
+      }
+    } catch (IOException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      LOG.warn("Unable to list installed .NET SDKs", e);
+      return List.of();
+    }
+  }
+
+  private String resolveDotnetExecutable(@Nullable Path dotnetCliPath) {
+    if (dotnetCliPath != null) {
+      return dotnetCliPath.toString();
+    }
+    return system2.isOsWindows() ? "dotnet.exe" : "dotnet";
+  }
+
+  static Optional<SdkInfo> parseListSdksLine(String line) {
+    Matcher matcher = LIST_SDKS_PATTERN.matcher(line);
+    if (!matcher.matches()) {
+      return Optional.empty();
+    }
+    return Optional.of(new SdkInfo(matcher.group(1), Path.of(matcher.group(2))));
+  }
+
+  static int compareSdkVersions(String left, String right) {
+    var leftParts = left.split("[.-]");
+    var rightParts = right.split("[.-]");
+    int length = Math.max(leftParts.length, rightParts.length);
+    for (int i = 0; i < length; i++) {
+      int leftPart = i < leftParts.length ? parseVersionPart(leftParts[i]) : 0;
+      int rightPart = i < rightParts.length ? parseVersionPart(rightParts[i]) : 0;
+      if (leftPart != rightPart) {
+        return Integer.compare(leftPart, rightPart);
+      }
+    }
+    return 0;
+  }
+
+  private static int parseVersionPart(String part) {
+    try {
+      return Integer.parseInt(part.replaceAll("\\D.*", ""));
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  static final class SdkInfo {
+    private final String version;
+    private final Path path;
+
+    private SdkInfo(String version, Path path) {
+      this.version = version;
+      this.path = path;
+    }
+
+    String version() {
+      return version;
+    }
+
+    Path path() {
+      return path;
+    }
+  }
+
+}

--- a/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpCommandBuilder.java
+++ b/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpCommandBuilder.java
@@ -59,7 +59,7 @@ public class OmnisharpCommandBuilder {
     }
     String omnisharpNet6Loc = getMandatoryConfig(CSharpPropertyDefinitions.getOmnisharpNet6Location());
     args.add(Paths.get(omnisharpNet6Loc).resolve("OmniSharp.dll").toString());
-    return addArguments(projectBaseDir, msBuildPath, solutionPath, loadProjectsOnDemand, args);
+    return addNet6Arguments(projectBaseDir, msBuildPath, solutionPath, loadProjectsOnDemand, args);
   }
 
   public ProcessBuilder build(Path projectBaseDir, @Nullable Path monoPath, @Nullable Path msBuildPath, @Nullable Path solutionPath, boolean loadProjectsOnDemand) {
@@ -79,6 +79,19 @@ public class OmnisharpCommandBuilder {
     return addArguments(projectBaseDir, msBuildPath, solutionPath, loadProjectsOnDemand, args);
   }
 
+  private ProcessBuilder addNet6Arguments(Path projectBaseDir, @Nullable Path msBuildPath, @Nullable Path solutionPath, boolean loadProjectsOnDemand, List<String> args) {
+    args.add("-v");
+    if (sonarLintRuntime.getClientPid() != 0) {
+      args.add("--hostPID");
+      args.add(Long.toString(sonarLintRuntime.getClientPid()));
+    }
+    DotNetSdkPathResolver.fromPathHint(msBuildPath).ifPresent(sdk -> {
+      args.add("Sdk:Path=" + sdk.path());
+      args.add("Sdk:Version=" + sdk.version());
+    });
+    return addCommonArguments(projectBaseDir, solutionPath, loadProjectsOnDemand, args);
+  }
+
   private ProcessBuilder addArguments(Path projectBaseDir, @Nullable Path msBuildPath, @Nullable Path solutionPath, boolean loadProjectsOnDemand, List<String> args) {
     args.add("-v");
     if (sonarLintRuntime.getClientPid() != 0) {
@@ -88,6 +101,10 @@ public class OmnisharpCommandBuilder {
     if (msBuildPath != null) {
       args.add("MsBuild:MSBuildOverride:MSBuildPath=" + msBuildPath.toString());
     }
+    return addCommonArguments(projectBaseDir, solutionPath, loadProjectsOnDemand, args);
+  }
+
+  private ProcessBuilder addCommonArguments(Path projectBaseDir, @Nullable Path solutionPath, boolean loadProjectsOnDemand, List<String> args) {
     args.add("MsBuild:loadProjectsOnDemand=" + loadProjectsOnDemand);
     args.add("DotNet:enablePackageRestore=false");
     args.add("--encoding");

--- a/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpPlugin.java
+++ b/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpPlugin.java
@@ -36,7 +36,8 @@ public class OmnisharpPlugin implements Plugin {
         OmnisharpServicesExtractor.class,
         OmnisharpFileListener.class,
         OmnisharpResponseProcessor.class,
-        OmnisharpCommandBuilder.class);
+        OmnisharpCommandBuilder.class,
+        DotNetSdkSelector.class);
     }
 
     context.addExtension(CSharpLanguage.class);

--- a/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpSensor.java
+++ b/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpSensor.java
@@ -55,10 +55,12 @@ public class OmnisharpSensor implements Sensor {
 
   private final OmnisharpServerController server;
   private final OmnisharpEndpoints omnisharpEndpoints;
+  private final DotNetSdkSelector dotNetSdkSelector;
 
-  public OmnisharpSensor(OmnisharpServerController server, OmnisharpEndpoints omnisharpEndpoints) {
+  public OmnisharpSensor(OmnisharpServerController server, OmnisharpEndpoints omnisharpEndpoints, DotNetSdkSelector dotNetSdkSelector) {
     this.server = server;
     this.omnisharpEndpoints = omnisharpEndpoints;
+    this.dotNetSdkSelector = dotNetSdkSelector;
   }
 
   @Override
@@ -84,11 +86,14 @@ public class OmnisharpSensor implements Sensor {
       Path monoExePath = context.config().get(CSharpPropertyDefinitions.getMonoExeLocation()).map(Paths::get).orElse(null);
       Path msBuildPath = context.config().get(CSharpPropertyDefinitions.getMSBuildPath()).map(Paths::get).orElse(null);
       Path solutionPath = context.config().get(CSharpPropertyDefinitions.getSolutionPath()).map(Paths::get).orElse(null);
-      boolean useFramework = context.config().getBoolean(CSharpPropertyDefinitions.getUseNet6()).orElse(false);
+      boolean useNet6 = context.config().getBoolean(CSharpPropertyDefinitions.getUseNet6()).orElse(false);
+      if (useNet6) {
+        msBuildPath = dotNetSdkSelector.selectCompatibleSdkPath(context.fileSystem().baseDir().toPath(), msBuildPath, dotnetCliExePath);
+      }
       boolean loadProjectsOnDemand = context.config().getBoolean(CSharpPropertyDefinitions.getLoadProjectsOnDemand()).orElse(false);
       int startupTimeOutSec = context.config().getInt(CSharpPropertyDefinitions.getStartupTimeout()).orElse(60);
       int loadProjectsTimeOutSec = context.config().getInt(CSharpPropertyDefinitions.getLoadProjectsTimeout()).orElse(60);
-      server.lazyStart(context.fileSystem().baseDir().toPath(), analyzerPluginPath, useFramework, loadProjectsOnDemand, dotnetCliExePath, monoExePath, msBuildPath, solutionPath,
+      server.lazyStart(context.fileSystem().baseDir().toPath(), analyzerPluginPath, useNet6, loadProjectsOnDemand, dotnetCliExePath, monoExePath, msBuildPath, solutionPath,
         startupTimeOutSec, loadProjectsTimeOutSec);
     } catch (InterruptedException e) {
       LOG.warn("Interrupted", e);

--- a/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/DotNetSdkPathResolverTests.java
+++ b/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/DotNetSdkPathResolverTests.java
@@ -1,0 +1,57 @@
+/*
+ * SonarOmnisharp
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.omnisharp;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DotNetSdkPathResolverTests {
+
+  @Test
+  void fromPathHint_extracts_sdk_from_standard_path() {
+    var sdkPath = Path.of("/usr/share/dotnet/sdk/8.0.422");
+
+    var sdk = DotNetSdkPathResolver.fromPathHint(sdkPath);
+
+    assertThat(sdk).isPresent();
+    assertThat(sdk.get().path()).isEqualTo(sdkPath);
+    assertThat(sdk.get().version()).isEqualTo("8.0.422");
+  }
+
+  @Test
+  void fromPathHint_extracts_sdk_from_msbuild_path_inside_sdk() {
+    var msBuildPath = Path.of("/usr/share/dotnet/sdk/8.0.422/MSBuild.dll");
+
+    var sdk = DotNetSdkPathResolver.fromPathHint(msBuildPath);
+
+    assertThat(sdk).isPresent();
+    assertThat(sdk.get().path()).isEqualTo(Path.of("/usr/share/dotnet/sdk/8.0.422"));
+    assertThat(sdk.get().version()).isEqualTo("8.0.422");
+  }
+
+  @Test
+  void isCompatibleSdkVersion_rejects_sdk_10_and_above() {
+    assertThat(DotNetSdkPathResolver.isCompatibleSdkVersion("9.0.100")).isTrue();
+    assertThat(DotNetSdkPathResolver.isCompatibleSdkVersion("10.0.301")).isFalse();
+  }
+
+}

--- a/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/DotNetSdkSelectorTests.java
+++ b/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/DotNetSdkSelectorTests.java
@@ -1,0 +1,57 @@
+/*
+ * SonarOmnisharp
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.omnisharp;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.utils.System2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class DotNetSdkSelectorTests {
+
+  private final DotNetSdkSelector underTest = new DotNetSdkSelector(mock(System2.class));
+
+  @Test
+  void selectCompatibleSdkPath_returns_compatible_hint_without_listing_sdks() {
+    var sdkPath = Path.of("/usr/share/dotnet/sdk/8.0.422");
+
+    var selected = underTest.selectCompatibleSdkPath(Path.of("/tmp/project"), sdkPath, null);
+
+    assertThat(selected).isEqualTo(sdkPath);
+  }
+
+  @Test
+  void parseListSdksLine_parses_dotnet_list_output() {
+    var sdk = DotNetSdkSelector.parseListSdksLine("8.0.422 [/usr/share/dotnet/sdk/8.0.422]");
+
+    assertThat(sdk).isPresent();
+    assertThat(sdk.get().version()).isEqualTo("8.0.422");
+    assertThat(sdk.get().path()).isEqualTo(Path.of("/usr/share/dotnet/sdk/8.0.422"));
+  }
+
+  @Test
+  void compareSdkVersions_orders_patch_versions_numerically() {
+    assertThat(DotNetSdkSelector.compareSdkVersions("8.0.422", "8.0.100")).isPositive();
+    assertThat(DotNetSdkSelector.compareSdkVersions("9.0.10", "9.0.9")).isPositive();
+  }
+
+}

--- a/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/OmnisharpCommandBuilderTests.java
+++ b/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/OmnisharpCommandBuilderTests.java
@@ -154,10 +154,31 @@ class OmnisharpCommandBuilderTests {
   }
 
   @Test
-  void buildCommand_pass_msbuild_location(@TempDir Path projectBaseDir, @TempDir Path solutionFile, @TempDir Path msbuildPath) {
-    var pb = underTest.buildNet6(projectBaseDir, null, msbuildPath, solutionFile, false);
+  void buildCommand_pass_sdk_location(@TempDir Path projectBaseDir, @TempDir Path solutionFile) {
+    var sdkPath = Path.of("/usr/share/dotnet/sdk/8.0.422");
+    var pb = underTest.buildNet6(projectBaseDir, null, sdkPath, solutionFile, false);
     assertThat(pb.command()).containsExactly("dotnet",
       omnisharpNet6Location.resolve("OmniSharp.dll").toString(),
+      "-v",
+      "Sdk:Path=" + sdkPath,
+      "Sdk:Version=8.0.422",
+      "MsBuild:loadProjectsOnDemand=false",
+      "DotNet:enablePackageRestore=false",
+      "--encoding",
+      "utf-8",
+      "-s",
+      solutionFile.toString(),
+      "--plugin",
+      omnisharpDllServicesPath.toString());
+  }
+
+  @Test
+  void buildCommand_legacy_pass_msbuild_location(@TempDir Path projectBaseDir, @TempDir Path solutionFile, @TempDir Path msbuildPath) {
+    when(system2.isOsWindows()).thenReturn(false);
+
+    var pb = underTest.build(projectBaseDir, null, msbuildPath, solutionFile, false);
+    assertThat(pb.command()).containsExactly("mono",
+      omnisharpMonoLocation.resolve("OmniSharp.exe").toString(),
       "-v",
       "MsBuild:MSBuildOverride:MSBuildPath=" + msbuildPath.toString(),
       "MsBuild:loadProjectsOnDemand=false",

--- a/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/OmnisharpSensorTests.java
+++ b/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/OmnisharpSensorTests.java
@@ -79,6 +79,7 @@ class OmnisharpSensorTests {
 
   private final OmnisharpServerController mockServer = mock(OmnisharpServerController.class);
   private final OmnisharpEndpoints mockProtocol = mock(OmnisharpEndpoints.class);
+  private final DotNetSdkSelector mockDotNetSdkSelector = mock(DotNetSdkSelector.class);
   @RegisterExtension
   LogTesterJUnit5 logTester = new LogTesterJUnit5();
   private OmnisharpSensor underTest;
@@ -111,7 +112,8 @@ class OmnisharpSensorTests {
   @BeforeEach
   void prepare(@TempDir Path tmp) throws Exception {
     baseDir = tmp.toRealPath();
-    underTest = new OmnisharpSensor(mockServer, mockProtocol);
+    underTest = new OmnisharpSensor(mockServer, mockProtocol, mockDotNetSdkSelector);
+    when(mockDotNetSdkSelector.selectCompatibleSdkPath(any(), any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
     when(mockServer.whenReady()).thenReturn(CompletableFuture.completedFuture(null));
   }
 


### PR DESCRIPTION
## Summary
- Add `DotNetSdkSelector` to pick a .NET SDK compatible with OmniSharp 1.39.x when SDK 10+ is installed on the machine.
- Ignore incompatible SDK hints from the IDE and fall back to `dotnet --list-sdks`, honoring `global.json` when present.
- Wire SDK selection into `OmnisharpSensor` for the net6 OmniSharp flavor.

Depends on #333 (SLOMNI-128).

## Test plan
- [x] `./mvn -pl omnisharp-plugin test -Dtest=DotNetSdkSelectorTests,OmnisharpSensorTests`
- [ ] Manual validation on a machine with both SDK 8 and SDK 10 installed