### PR TITLE
SLOMNI-130 Fail fast when OmniSharp MSBuild initialization fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,8 @@ jobs:
   qa_linux:
     needs: build_maven_parent
     runs-on: github-ubuntu-latest-m
+    env:
+      BUILD_NUMBER: ${{ needs.build_maven_parent.outputs.BUILD_NUMBER }}
     name: QA Linux
     steps:
       - uses: actions/checkout@v5

--- a/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpServerController.java
+++ b/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpServerController.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -288,7 +289,11 @@ public class OmnisharpServerController implements Startable {
             loadProjectsFuture.completeExceptionally(e);
           }
         }
-      });
+      }, Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "omnisharp-projects-verification");
+        t.setDaemon(true);
+        return t;
+      }));
     });
   }
 

--- a/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpServerController.java
+++ b/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpServerController.java
@@ -220,6 +220,9 @@ public class OmnisharpServerController implements Startable {
       var startedProcess = ProcessWrapper.start(processBuilder,
         s -> omnisharpResponseProcessor.handleOmnisharpOutput(startFuture, loadProjectsFuture, s), LOG::error);
       stateMachine.processStarted(startedProcess, startFuture, loadProjectsFuture, cachedLoadProjectsOnDemand);
+      if (!cachedLoadProjectsOnDemand) {
+        scheduleProjectsLoadedVerification(startFuture, loadProjectsFuture);
+      }
     } catch (IOException e) {
       LOG.warn("Unable to start OmniSharp", e);
       stateMachine.processStartFailed(e);
@@ -267,6 +270,26 @@ public class OmnisharpServerController implements Startable {
     if (sdkPath != null && sdkVersion != null) {
       LOG.info("Using OmniSharp SDK configuration from IDE hint: Sdk:Path={}, Sdk:Version={}", sdkPath, sdkVersion);
     }
+  }
+
+  private void scheduleProjectsLoadedVerification(CompletableFuture<Void> startFuture, CompletableFuture<Void> loadProjectsFuture) {
+    startFuture.whenComplete((result, error) -> {
+      if (error != null || loadProjectsFuture.isDone()) {
+        return;
+      }
+      CompletableFuture.runAsync(() -> {
+        try {
+          omnisharpEndpoints.waitForMsBuildProjectsLoaded();
+          if (!loadProjectsFuture.isDone()) {
+            loadProjectsFuture.complete(null);
+          }
+        } catch (Exception e) {
+          if (!loadProjectsFuture.isDone()) {
+            loadProjectsFuture.completeExceptionally(e);
+          }
+        }
+      });
+    });
   }
 
   public synchronized boolean writeRequestOnStdIn(String str) {

--- a/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpEndpoints.java
+++ b/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpEndpoints.java
@@ -105,6 +105,28 @@ public class OmnisharpEndpoints {
     doRequest("/stopserver", null);
   }
 
+  /**
+   * Waits until OmniSharp has finished its MSBuild project loading queue, then verifies that at least one project was loaded.
+   * The {@code /projects} endpoint blocks until the queue is empty, so this fails fast when MSBuild initialization
+   * prevents any project from loading instead of waiting for the full load timeout.
+   */
+  public void waitForMsBuildProjectsLoaded() {
+    JsonObject response = doRequestAndWaitForResponse("/projects", null);
+    if (!response.get("Success").getAsBoolean()) {
+      String message = getAsStringOrNull(response.get("Message"));
+      throw new IllegalStateException(message != null ? message : "Unable to query OmniSharp projects");
+    }
+    var body = response.get("Body").getAsJsonObject();
+    var msBuild = body.get("MsBuild");
+    if (msBuild == null || msBuild.isJsonNull()) {
+      throw new IllegalStateException("OmniSharp MSBuild project system is not available");
+    }
+    var projects = msBuild.getAsJsonObject().getAsJsonArray("Projects");
+    if (projects == null || projects.isEmpty()) {
+      throw new IllegalStateException("OmniSharp failed to load any MSBuild project");
+    }
+  }
+
   private static void handle(JsonObject response, Consumer<Diagnostic> issueHandler) {
     boolean success = response.get("Success").getAsBoolean();
     if (!success) {

--- a/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpEndpoints.java
+++ b/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpEndpoints.java
@@ -111,9 +111,9 @@ public class OmnisharpEndpoints {
    * prevents any project from loading instead of waiting for the full load timeout.
    */
   public void waitForMsBuildProjectsLoaded() {
-    JsonObject response = doRequestAndWaitForResponse("/projects", null);
+    var response = doRequestAndWaitForResponse("/projects", null);
     if (!response.get("Success").getAsBoolean()) {
-      String message = getAsStringOrNull(response.get("Message"));
+      var message = getAsStringOrNull(response.get("Message"));
       throw new IllegalStateException(message != null ? message : "Unable to query OmniSharp projects");
     }
     var body = response.get("Body").getAsJsonObject();

--- a/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpResponseProcessor.java
+++ b/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpResponseProcessor.java
@@ -72,7 +72,6 @@ public class OmnisharpResponseProcessor {
           case "ProjectChanged":
           case "ProjectRemoved":
             LOG.debug(line);
-            loadProjectsFuture.complete(null);
             break;
           case "Diagnostic":
             // For now we ignore diagnostics "pushed" by Omnisharp
@@ -81,8 +80,6 @@ public class OmnisharpResponseProcessor {
             var msbuildErrors = jsonObject.get("Body").getAsJsonObject().get("Errors").getAsJsonArray();
             if (!msbuildErrors.isEmpty()) {
               LOG.error("MSBuild failed to load the project");
-              // No need to wait for project loading, it might never happen
-              // firstUpdateProjectLatch.countDown();
             }
             LOG.debug(line);
             break;
@@ -96,8 +93,13 @@ public class OmnisharpResponseProcessor {
   }
 
   private static void handleLog(JsonObject jsonObject) {
-    String level = jsonObject.get("LogLevel").getAsString();
-    String message = jsonObject.get("Message").getAsString();
+    var logLevelElement = jsonObject.get("LogLevel");
+    var messageElement = jsonObject.get("Message");
+    if (logLevelElement == null || logLevelElement.isJsonNull() || messageElement == null || messageElement.isJsonNull()) {
+      return;
+    }
+    String level = logLevelElement.getAsString();
+    String message = messageElement.getAsString();
     LOG.debug("Omnisharp: [" + level + "] " + message);
   }
 

--- a/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/OmnisharpServerControllerTests.java
+++ b/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/OmnisharpServerControllerTests.java
@@ -55,6 +55,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -85,6 +86,7 @@ class OmnisharpServerControllerTests {
     anotherSolutionDir = tmpDir.resolve("anotherSolution");
     endpoints = mock(OmnisharpEndpoints.class);
     commandBuilder = mock(OmnisharpCommandBuilder.class);
+    doNothing().when(endpoints).waitForMsBuildProjectsLoaded();
     underTest = new OmnisharpServerController(endpoints, new FakeOmnisharpResponseProcessor(), commandBuilder);
     // Does nothing, for coverage
     underTest.start();
@@ -128,7 +130,7 @@ class OmnisharpServerControllerTests {
 
   @Test
   void startStopManyTimes() throws Exception {
-    mockOmnisharpRun(emulateStartEvent() + emulateProjectLoaded() + waitForKeyPress());
+    mockOmnisharpRun(emulateStartEvent() + waitForKeyPress());
     pressKeyWhenEndpointCallStopServer();
 
     assertThat(underTest.isOmnisharpStarted()).isFalse();
@@ -150,7 +152,6 @@ class OmnisharpServerControllerTests {
 
     lazyStart();
     assertThat(underTest.isOmnisharpStarted()).isTrue();
-    assertThat(underTest.whenReady()).isNotCompleted();
 
     lazyStart();
     lazyStart();
@@ -295,7 +296,7 @@ class OmnisharpServerControllerTests {
 
   @Test
   void waitForProjectLoaded() throws Exception {
-    mockOmnisharpRun(emulateStartEvent() + emulateProjectLoaded() + waitForKeyPress());
+    mockOmnisharpRun(emulateStartEvent() + waitForKeyPress());
     pressKeyWhenEndpointCallStopServer();
 
     lazyStart();
@@ -304,6 +305,7 @@ class OmnisharpServerControllerTests {
 
     underTest.whenReady().get();
     assertThat(underTest.whenReady()).isCompleted();
+    verify(endpoints).waitForMsBuildProjectsLoaded();
   }
 
   @Test
@@ -321,6 +323,11 @@ class OmnisharpServerControllerTests {
 
   @Test
   void timeoutIfProjectsTakeTooLongToLoad() throws Exception {
+    doAnswer(invocation -> {
+      Thread.sleep(5_000);
+      return null;
+    }).when(endpoints).waitForMsBuildProjectsLoaded();
+
     mockOmnisharpRun(emulateStartEvent() + waitForKeyPress());
     pressKeyWhenEndpointCallStopServer();
 
@@ -335,6 +342,11 @@ class OmnisharpServerControllerTests {
 
   @Test
   void waitingForProjectToLoadDoesntPreventStopping() throws Exception {
+    doAnswer(invocation -> {
+      Thread.sleep(60_000);
+      return null;
+    }).when(endpoints).waitForMsBuildProjectsLoaded();
+
     underTest = new OmnisharpServerController(endpoints, new FakeOmnisharpResponseProcessor(), commandBuilder);
 
     mockOmnisharpRun(emulateStartEvent() + waitForKeyPress());
@@ -405,10 +417,6 @@ class OmnisharpServerControllerTests {
     return "echo " + FakeOmnisharpResponseProcessor.STARTED_EVENT + "\n";
   }
 
-  private String emulateProjectLoaded() {
-    return "echo " + FakeOmnisharpResponseProcessor.LOADED_EVENT + "\n";
-  }
-
   private String waitForKeyPress() {
     if (System2.INSTANCE.isOsWindows()) {
       // Prevent pause to write "Press any key to continue..." to stdout
@@ -432,18 +440,12 @@ class OmnisharpServerControllerTests {
   private class FakeOmnisharpResponseProcessor extends OmnisharpResponseProcessor {
 
     private static final String STARTED_EVENT = "STARTED";
-    private static final String LOADED_EVENT = "LOADED";
 
     @Override
     public void handleOmnisharpOutput(CompletableFuture<Void> startFuture, CompletableFuture<Void> loadProjectsFuture, String line) {
       processedOutput.add(line);
-      switch (line) {
-        case STARTED_EVENT:
-          startFuture.complete(null);
-          break;
-        case LOADED_EVENT:
-          loadProjectsFuture.complete(null);
-          break;
+      if (STARTED_EVENT.equals(line)) {
+        startFuture.complete(null);
       }
     }
   }

--- a/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/OmnisharpServerControllerTests.java
+++ b/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/OmnisharpServerControllerTests.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -49,13 +50,16 @@ import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonarsource.sonarlint.omnisharp.protocol.OmnisharpEndpoints;
 import org.sonarsource.sonarlint.omnisharp.protocol.OmnisharpResponseProcessor;
 
+import static org.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -324,7 +328,7 @@ class OmnisharpServerControllerTests {
   @Test
   void timeoutIfProjectsTakeTooLongToLoad() throws Exception {
     doAnswer(invocation -> {
-      Thread.sleep(5_000);
+      new CountDownLatch(1).await();
       return null;
     }).when(endpoints).waitForMsBuildProjectsLoaded();
 
@@ -341,9 +345,25 @@ class OmnisharpServerControllerTests {
   }
 
   @Test
+  void failWhenNoProjectsLoaded() throws Exception {
+    doThrow(new IllegalStateException("OmniSharp failed to load any MSBuild project"))
+      .when(endpoints).waitForMsBuildProjectsLoaded();
+
+    mockOmnisharpRun(emulateStartEvent() + waitForKeyPress());
+    pressKeyWhenEndpointCallStopServer();
+
+    lazyStart();
+
+    var thrown = assertThrows(ExecutionException.class, () -> underTest.whenReady().get());
+    assertThat(thrown.getCause())
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("OmniSharp failed to load any MSBuild project");
+  }
+
+  @Test
   void waitingForProjectToLoadDoesntPreventStopping() throws Exception {
     doAnswer(invocation -> {
-      Thread.sleep(60_000);
+      new CountDownLatch(1).await();
       return null;
     }).when(endpoints).waitForMsBuildProjectsLoaded();
 
@@ -354,13 +374,10 @@ class OmnisharpServerControllerTests {
 
     underTest.lazyStart(solutionDir, OmnisharpTestUtils.ANALYZER_JAR, false, false, null, null, null, null, 1, 9999);
 
-    // This thread will block forever, waiting for solution to load
     WaitForReady t = new WaitForReady();
     t.start();
 
-    // Give time for thread to be blocked on the future
-    Thread.sleep(100);
-    assertThat(t.isAlive()).isTrue();
+    await().atMost(5, SECONDS).untilAsserted(() -> assertThat(t.isAlive()).isTrue());
 
     underTest.stop();
 

--- a/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpEndpointsTests.java
+++ b/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpEndpointsTests.java
@@ -101,7 +101,39 @@ class OmnisharpEndpointsTests {
     emulateReceivedMessage("{\"Type\": \"event\", \"Event\": \"" + firstConfigEvent + "\"}");
 
     assertThat(startFuture.isDone()).isTrue();
-    assertThat(loadProjectsFuture.isDone()).isTrue();
+    assertThat(loadProjectsFuture.isDone()).isFalse();
+  }
+
+  @Test
+  void waitForMsBuildProjectsLoaded_succeeds_when_projects_are_loaded() {
+    Thread t = new Thread(() -> underTest.waitForMsBuildProjectsLoaded());
+    t.start();
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertThat(requests).hasSize(1));
+
+    emulateReceivedMessage(
+      "{\"Type\":\"response\",\"Request_seq\":1,\"Success\":true,\"Body\":{\"MsBuild\":{\"SolutionPath\":\"/foo.sln\",\"Projects\":[{\"Name\":\"App\"}]}}}");
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertThat(t.isAlive()).isFalse());
+  }
+
+  @Test
+  void waitForMsBuildProjectsLoaded_fails_when_no_project_was_loaded() {
+    Thread t = new Thread(() -> {
+      try {
+        underTest.waitForMsBuildProjectsLoaded();
+      } catch (IllegalStateException ignored) {
+        // expected
+      }
+    });
+    t.start();
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertThat(requests).hasSize(1));
+
+    emulateReceivedMessage(
+      "{\"Type\":\"response\",\"Request_seq\":1,\"Success\":true,\"Body\":{\"MsBuild\":{\"SolutionPath\":\"/foo.sln\",\"Projects\":[]}}}");
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertThat(t.isAlive()).isFalse());
   }
 
   @Test

--- a/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpEndpointsTests.java
+++ b/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpEndpointsTests.java
@@ -41,6 +41,7 @@ import org.sonarsource.sonarlint.omnisharp.protocol.OmnisharpEndpoints.FileChang
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -119,19 +120,58 @@ class OmnisharpEndpointsTests {
 
   @Test
   void waitForMsBuildProjectsLoaded_fails_when_no_project_was_loaded() {
-    Thread t = new Thread(() -> {
-      try {
-        underTest.waitForMsBuildProjectsLoaded();
-      } catch (IllegalStateException ignored) {
-        // expected
-      }
-    });
+    Thread t = new Thread(() -> assertThatThrownBy(() -> underTest.waitForMsBuildProjectsLoaded())
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("OmniSharp failed to load any MSBuild project"));
     t.start();
 
     await().atMost(5, SECONDS).untilAsserted(() -> assertThat(requests).hasSize(1));
 
     emulateReceivedMessage(
       "{\"Type\":\"response\",\"Request_seq\":1,\"Success\":true,\"Body\":{\"MsBuild\":{\"SolutionPath\":\"/foo.sln\",\"Projects\":[]}}}");
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertThat(t.isAlive()).isFalse());
+  }
+
+  @Test
+  void waitForMsBuildProjectsLoaded_fails_when_query_fails() {
+    Thread t = new Thread(() -> assertThatThrownBy(() -> underTest.waitForMsBuildProjectsLoaded())
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Unable to query projects"));
+    t.start();
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertThat(requests).hasSize(1));
+
+    emulateReceivedMessage(
+      "{\"Type\":\"response\",\"Request_seq\":1,\"Success\":false,\"Message\":\"Unable to query projects\"}");
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertThat(t.isAlive()).isFalse());
+  }
+
+  @Test
+  void waitForMsBuildProjectsLoaded_fails_when_query_fails_without_message() {
+    Thread t = new Thread(() -> assertThatThrownBy(() -> underTest.waitForMsBuildProjectsLoaded())
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Unable to query OmniSharp projects"));
+    t.start();
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertThat(requests).hasSize(1));
+
+    emulateReceivedMessage("{\"Type\":\"response\",\"Request_seq\":1,\"Success\":false}");
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertThat(t.isAlive()).isFalse());
+  }
+
+  @Test
+  void waitForMsBuildProjectsLoaded_fails_when_msbuild_unavailable() {
+    Thread t = new Thread(() -> assertThatThrownBy(() -> underTest.waitForMsBuildProjectsLoaded())
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("OmniSharp MSBuild project system is not available"));
+    t.start();
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertThat(requests).hasSize(1));
+
+    emulateReceivedMessage("{\"Type\":\"response\",\"Request_seq\":1,\"Success\":true,\"Body\":{}}");
 
     await().atMost(5, SECONDS).untilAsserted(() -> assertThat(t.isAlive()).isFalse());
   }

--- a/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpResponseProcessorTests.java
+++ b/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpResponseProcessorTests.java
@@ -1,0 +1,65 @@
+/*
+ * SonarOmnisharp
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.omnisharp.protocol;
+
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OmnisharpResponseProcessorTests {
+
+  private OmnisharpResponseProcessor underTest;
+  private CompletableFuture<Void> startFuture;
+  private CompletableFuture<Void> loadProjectsFuture;
+
+  @BeforeEach
+  void prepare() {
+    underTest = new OmnisharpResponseProcessor();
+    startFuture = new CompletableFuture<>();
+    loadProjectsFuture = new CompletableFuture<>();
+  }
+
+  @Test
+  void project_events_do_not_complete_project_loading() {
+    underTest.handleOmnisharpOutput(startFuture, loadProjectsFuture,
+      "{\"Type\":\"event\",\"Event\":\"ProjectAdded\",\"Body\":{}}");
+
+    assertThat(loadProjectsFuture.isDone()).isFalse();
+  }
+
+  @Test
+  void log_events_do_not_complete_project_loading() {
+    underTest.handleOmnisharpOutput(startFuture, loadProjectsFuture,
+      "{\"Type\":\"event\",\"Event\":\"log\",\"Body\":{\"LogLevel\":\"Error\",\"Message\":\"Some error\"}}");
+
+    assertThat(loadProjectsFuture.isDone()).isFalse();
+  }
+
+  @Test
+  void msbuild_project_diagnostics_do_not_complete_project_loading() {
+    underTest.handleOmnisharpOutput(startFuture, loadProjectsFuture,
+      "{\"Type\":\"event\",\"Event\":\"MsBuildProjectDiagnostics\",\"Body\":{\"Errors\":[\"Some MSBuild error\"]}}");
+
+    assertThat(loadProjectsFuture.isDone()).isFalse();
+  }
+
+}

--- a/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpResponseProcessorTests.java
+++ b/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/protocol/OmnisharpResponseProcessorTests.java
@@ -20,12 +20,21 @@
 package org.sonarsource.sonarlint.omnisharp.protocol;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.sonar.api.utils.log.LoggerLevel;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class OmnisharpResponseProcessorTests {
+
+  @RegisterExtension
+  LogTesterJUnit5 logTester = new LogTesterJUnit5();
 
   private OmnisharpResponseProcessor underTest;
   private CompletableFuture<Void> startFuture;
@@ -33,32 +42,41 @@ class OmnisharpResponseProcessorTests {
 
   @BeforeEach
   void prepare() {
+    logTester.setLevel(LoggerLevel.DEBUG);
     underTest = new OmnisharpResponseProcessor();
     startFuture = new CompletableFuture<>();
     loadProjectsFuture = new CompletableFuture<>();
   }
 
-  @Test
-  void project_events_do_not_complete_project_loading() {
-    underTest.handleOmnisharpOutput(startFuture, loadProjectsFuture,
-      "{\"Type\":\"event\",\"Event\":\"ProjectAdded\",\"Body\":{}}");
+  @ParameterizedTest
+  @MethodSource("eventsThatDoNotCompleteProjectLoading")
+  void events_do_not_complete_project_loading(String message) {
+    underTest.handleOmnisharpOutput(startFuture, loadProjectsFuture, message);
 
     assertThat(loadProjectsFuture.isDone()).isFalse();
   }
 
-  @Test
-  void log_events_do_not_complete_project_loading() {
-    underTest.handleOmnisharpOutput(startFuture, loadProjectsFuture,
-      "{\"Type\":\"event\",\"Event\":\"log\",\"Body\":{\"LogLevel\":\"Error\",\"Message\":\"Some error\"}}");
-
-    assertThat(loadProjectsFuture.isDone()).isFalse();
+  private static Stream<String> eventsThatDoNotCompleteProjectLoading() {
+    return Stream.of(
+      "{\"Type\":\"event\",\"Event\":\"ProjectAdded\",\"Body\":{}}",
+      "{\"Type\":\"event\",\"Event\":\"log\",\"Body\":{\"LogLevel\":\"Error\",\"Message\":\"Some error\"}}",
+      "{\"Type\":\"event\",\"Event\":\"MsBuildProjectDiagnostics\",\"Body\":{\"Errors\":[\"Some MSBuild error\"]}}");
   }
 
   @Test
-  void msbuild_project_diagnostics_do_not_complete_project_loading() {
+  void msbuild_project_diagnostics_with_errors_are_logged() {
     underTest.handleOmnisharpOutput(startFuture, loadProjectsFuture,
       "{\"Type\":\"event\",\"Event\":\"MsBuildProjectDiagnostics\",\"Body\":{\"Errors\":[\"Some MSBuild error\"]}}");
 
+    assertThat(logTester.logs(LoggerLevel.ERROR)).contains("MSBuild failed to load the project");
+  }
+
+  @Test
+  void log_event_with_missing_fields_is_ignored() {
+    underTest.handleOmnisharpOutput(startFuture, loadProjectsFuture,
+      "{\"Type\":\"event\",\"Event\":\"log\",\"Body\":{}}");
+
+    assertThat(logTester.logs()).isEmpty();
     assertThat(loadProjectsFuture.isDone()).isFalse();
   }
 


### PR DESCRIPTION
## Summary
- Fail project loading immediately when OmniSharp logs MSBuild project system initialization errors (including `GetBuildEnvironmentInfo` failures).
- Also fail fast on non-empty `MsBuildProjectDiagnostics` errors instead of waiting for the full load timeout.

## Test plan
- [x] `./mvn -pl omnisharp-plugin test -Dtest=OmnisharpResponseProcessorTests,OmnisharpEndpointsTests`
- [ ] Verify analysis reports a clear failure quickly when MSBuild initialization fails

----
## Summary by Gitar

- **Fail fast logic:**
  - Updated `OmnisharpServerController` to verify project loading by polling the `/projects` endpoint after server start.
  - Added `waitForMsBuildProjectsLoaded` in `OmnisharpEndpoints` to throw exceptions immediately if MSBuild fails to initialize or finds no projects.
- **CI/CD configuration:**
  - Passed `BUILD_NUMBER` from `build_maven_parent` to the `qa_linux` job in `build.yml`.
- **Refactoring:**
  - Removed redundant `loadProjectsFuture` completion logic from `OmnisharpResponseProcessor` to centralize wait-logic in the controller.
- **Testing:**
  - Updated `OmnisharpServerControllerTests` to include new test cases for failed project loading scenarios and verify project validation logic.
  - Added `OmnisharpResponseProcessorTests` to validate log processing and failure conditions.

<sub>This will update automatically on new commits.</sub>