### PR TITLE
SLOMNI-132 Fetch the build number before other jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,26 @@ permissions:
   contents: write
 
 jobs:
+  build_number:
+    runs-on: github-ubuntu-latest-s
+    name: Get build number
+    outputs:
+      BUILD_NUMBER: ${{ steps.build-number.outputs.BUILD_NUMBER }}
+    permissions:
+      id-token: write
+    steps:
+      - uses: SonarSource/ci-github-actions/get-build-number@657e44543f55422ffd28b91d62fe5386f07d6030 # 1.6.0
+        id: build-number
+
   build_maven_parent:
+    needs: build_number
     runs-on: github-ubuntu-latest-m
     name: Build Maven Parent
-    outputs:
-      BUILD_NUMBER: ${{ steps.build-maven-action.outputs.BUILD_NUMBER }}
     permissions:
       id-token: write
       contents: write
+    env:
+      BUILD_NUMBER: ${{ needs.build_number.outputs.BUILD_NUMBER }}
     steps:
       - uses: actions/checkout@v5
 
@@ -73,7 +85,6 @@ jobs:
             --no-restore
 
       - uses: SonarSource/ci-github-actions/build-maven@9456e3aab93a6c6d0c459b977aaa594bda102e29 # 1.4.0
-        id: build-maven-action
         with:
           maven-args: -DskipIts
           sonar-platform: none
@@ -81,15 +92,15 @@ jobs:
           artifactory-deployer-role: qa-deployer
           deploy-pull-request: true
 
-      - name: Debug Build Number
-        run: echo "BUILD_NUMBER=${{ steps.build-maven-action.outputs.BUILD_NUMBER }}"
-
   build_dotnet:
+    needs: build_number
     runs-on: github-ubuntu-latest-m
     name: Build Dotnet
     permissions:
       id-token: write
       contents: write
+    env:
+      BUILD_NUMBER: ${{ needs.build_number.outputs.BUILD_NUMBER }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -140,9 +151,13 @@ jobs:
           path: omnisharp-dotnet/JarContentFiles/SonarLint.OmniSharp.DotNet.Services.dll
 
   qa_linux:
-    needs: build_maven_parent
+    needs:
+      - build_number
+      - build_maven_parent
     runs-on: github-ubuntu-latest-m
     name: QA Linux
+    env:
+      BUILD_NUMBER: ${{ needs.build_number.outputs.BUILD_NUMBER }}
     steps:
       - uses: actions/checkout@v5
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
@@ -189,10 +204,12 @@ jobs:
           path: '**/surefire-reports/TEST-*.xml'
 
   qa_windows:
-    needs: build_maven_parent
+    needs:
+      - build_number
+      - build_maven_parent
     runs-on: warp-custom-sonarlint-visualstudio
     env:
-      BUILD_NUMBER: ${{ needs.build_maven_parent.outputs.BUILD_NUMBER }}
+      BUILD_NUMBER: ${{ needs.build_number.outputs.BUILD_NUMBER }}
     name: QA Windows
     steps:
       - uses: actions/checkout@v5
@@ -230,9 +247,13 @@ jobs:
           path: '**/surefire-reports/TEST-*.xml'
 
   validate_linux:
-    needs: build_dotnet
+    needs:
+      - build_number
+      - build_dotnet
     runs-on: github-ubuntu-latest-m
     name: Validate Linux
+    env:
+      BUILD_NUMBER: ${{ needs.build_number.outputs.BUILD_NUMBER }}
     steps:
       - uses: actions/checkout@v5 # v5.0.0
         with:
@@ -270,9 +291,13 @@ jobs:
           artifactory-reader-role: private-reader
 
   validate_windows:
-    needs: build_dotnet
+    needs:
+      - build_number
+      - build_dotnet
     runs-on: github-windows-latest-m
     name: Validate Windows
+    env:
+      BUILD_NUMBER: ${{ needs.build_number.outputs.BUILD_NUMBER }}
     steps:
       - uses: actions/checkout@v5 # v5.0.0
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
@@ -308,6 +333,7 @@ jobs:
 
   promote:
     needs:
+      - build_number
       - build_maven_parent
       - validate_linux
       - validate_windows
@@ -315,6 +341,8 @@ jobs:
       - qa_windows
     runs-on: github-ubuntu-latest-s
     name: Promote
+    env:
+      BUILD_NUMBER: ${{ needs.build_number.outputs.BUILD_NUMBER }}
     steps:
       - uses: SonarSource/ci-github-actions/promote@9456e3aab93a6c6d0c459b977aaa594bda102e29 # 1.4.0
         with:


### PR DESCRIPTION
----
## Summary by Gitar

- **CI workflow optimization:**
  - Added `build_number` job to fetch build number centrally before other stages.
  - Updated `build_maven_parent`, `build_dotnet`, `qa_linux`, `qa_windows`, `validate_linux`, `validate_windows`, and `promote` jobs to consume `BUILD_NUMBER` via the new `build_number` dependency.

<sub>This will update automatically on new commits.</sub>