### PR TITLE
SLOMNI-138 Fix flaky test

### DIFF
--- a/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/OmnisharpServerControllerTests.java
+++ b/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/OmnisharpServerControllerTests.java
@@ -227,11 +227,13 @@ class OmnisharpServerControllerTests {
 
     System.out.println("First run");
     first.run();
+    underTest.whenReady().get();
     assertThat(underTest.isOmnisharpStarted()).isTrue();
     verify(endpoints, never()).stopServer();
 
     System.out.println("Second run");
     second.run();
+    underTest.whenReady().get();
     verify(endpoints).stopServer();
     assertThat(processedOutput).containsExactly("STARTED", "STARTED");
     assertThat(logTester.logs(Level.INFO)).contains(expectedMsg);


### PR DESCRIPTION
----
## Summary by Gitar

- **Test stability:**
  - Added `underTest.whenReady().get()` to wait for server initialization in `OmnisharpServerControllerTests`.
  - Ensured sequential runs complete before assertions to prevent flakiness in test execution.

<sub>This will update automatically on new commits.</sub>