### PR TITLE
[DO NOT MERGE] BISECT: revert sonarlint-core, keep analyzer 10.29.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <jdk.min.version>11</jdk.min.version>
     <omnisharp.version>1.39.15</omnisharp.version>
     <omnisharp.binaries.baseUrl>https://binaries.sonarsource.com/OmniSharp-Roslyn/${omnisharp.version}</omnisharp.binaries.baseUrl>
-    <analyzer.version>10.28.0.143324</analyzer.version>
+    <analyzer.version>10.29.0.143774</analyzer.version>
     <license.name>GNU LGPL v3</license.name>
     <sonar.organization>sonarsource</sonar.organization>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <gitRepositoryName>sonarlint-omnisharp</gitRepositoryName>
     <artifactsToPublish>${project.groupId}:sonarlint-omnisharp-plugin:jar</artifactsToPublish>
     <junit.version>5.9.1</junit.version>
-    <sonarlint-core.version>11.7.0.86025</sonarlint-core.version>
+    <sonarlint-core.version>11.1.0.85284</sonarlint-core.version>
     <jdk.min.version>11</jdk.min.version>
     <omnisharp.version>1.39.15</omnisharp.version>
     <omnisharp.binaries.baseUrl>https://binaries.sonarsource.com/OmniSharp-Roslyn/${omnisharp.version}</omnisharp.binaries.baseUrl>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <gitRepositoryName>sonarlint-omnisharp</gitRepositoryName>
     <artifactsToPublish>${project.groupId}:sonarlint-omnisharp-plugin:jar</artifactsToPublish>
     <junit.version>5.9.1</junit.version>
-    <sonarlint-core.version>11.1.0.85284</sonarlint-core.version>
+    <sonarlint-core.version>11.7.0.86025</sonarlint-core.version>
     <jdk.min.version>11</jdk.min.version>
     <omnisharp.version>1.39.15</omnisharp.version>
     <omnisharp.binaries.baseUrl>https://binaries.sonarsource.com/OmniSharp-Roslyn/${omnisharp.version}</omnisharp.binaries.baseUrl>


### PR DESCRIPTION
**Do not merge / do not review — CI bisection experiment for #348.**

PR #348 (analyzer 10.29.0 + sonarlint-core 11.7.0) fails `OmnisharpIntegrationTests.analyzeNet8SolutionWithSdkPathHint` deterministically on QA Linux + Windows (first analysis returns 0 issues; OmniSharp SDK-hint launch never happens).

This branch keeps the analyzer bump (10.29.0) but reverts **only** `sonarlint-core` to 11.1.0.85284, to isolate which dependency causes the regression:
- QA **green** here → `sonarlint-core` 11.7.0 is the culprit.
- QA **still red** → the analyzer bump (or both) is responsible.

Will be deleted after the QA result is read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)