### PR TITLE
Fix Unicode path matching

### DIFF
--- a/its/src/test/java/org/sonarsource/sonarlint/omnisharp/its/OmnisharpIntegrationTests.java
+++ b/its/src/test/java/org/sonarsource/sonarlint/omnisharp/its/OmnisharpIntegrationTests.java
@@ -220,6 +220,34 @@ class OmnisharpIntegrationTests {
   }
 
   @Test
+  void analyzeCSharpFileWithUnicodePath(@TempDir Path tmpDir) throws Exception {
+    Path baseDir = prepareTestSolutionAndRestore(tmpDir, "ConsoleAppNet5");
+    backend.getRulesService().updateStandaloneRulesConfiguration(new UpdateStandaloneRulesConfigurationParams(Map.of(
+      "csharpsquid:S103", new StandaloneRuleConfigDto(true, Map.of())
+    )));
+    var relativePath = "ConsoleApp1/diretório/TipoPrestaçãoColeção.cs";
+    var content = "namespace ConsoleApp1\n"
+      + "{\n"
+      + "    public static class TipoPrestaçãoColeção\n"
+      + "    {\n"
+      + "        public const string Message = \"" + "x".repeat(180) + "\";\n"
+      + "        public static string Nome => Message;\n"
+      + "    }\n"
+      + "}";
+    var filePath = baseDir.resolve(relativePath);
+    Files.createDirectories(filePath.getParent());
+    Files.writeString(filePath, content, StandardCharsets.UTF_8);
+
+    var issues = analyzeCSharpFile(SOLUTION1_MODULE_KEY, baseDir.toString(), relativePath, content,
+      "sonar.cs.internal.useNet6", "true",
+      "sonar.cs.internal.solutionPath", baseDir.resolve("ConsoleApp1.sln").toString());
+
+    assertThat(issues)
+      .extracting(RaisedIssueDto::getRuleKey)
+      .containsExactly("csharpsquid:S103");
+  }
+
+  @Test
   void analyzeNet6Solution(@TempDir Path tmpDir) throws Exception {
     Path baseDir = prepareTestSolutionAndRestore(tmpDir, "DotNet6Project");
     var issues = analyzeCSharpFile(SOLUTION1_MODULE_KEY, baseDir.toString(), "DotNet6Project/Program.cs", "// TODO foo\\n\"\n" +

--- a/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpSensor.java
+++ b/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpSensor.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonObject;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.Normalizer;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -240,7 +241,15 @@ public class OmnisharpSensor implements Sensor {
   }
 
   private static InputFile findInputFile(SensorContext context, Path filePath) {
-    return context.fileSystem().inputFile(context.fileSystem().predicates().is(filePath.toFile()));
+    var normalizedFilePath = normalizePath(filePath);
+    return StreamSupport.stream(context.fileSystem().inputFiles(context.fileSystem().predicates().all()).spliterator(), false)
+      .filter(inputFile -> normalizedFilePath.equals(normalizePath(Paths.get(inputFile.uri()))))
+      .findFirst()
+      .orElse(null);
+  }
+
+  private static Path normalizePath(Path path) {
+    return Paths.get(Normalizer.normalize(path.toAbsolutePath().normalize().toString(), Normalizer.Form.NFC));
   }
 
   private static NewIssueLocation createLocation(NewIssue newIssue, DiagnosticLocation location, InputFile inputFile) {

--- a/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpSensor.java
+++ b/omnisharp-plugin/src/main/java/org/sonarsource/sonarlint/omnisharp/OmnisharpSensor.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.Normalizer;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -125,6 +126,7 @@ public class OmnisharpSensor implements Sensor {
   private void analyze(SensorContext context, FilePredicate predicate) {
     JsonObject config = buildRulesConfig(context);
     omnisharpEndpoints.config(config);
+    Map<Path, InputFile> inputFilesByPath = indexInputFiles(context);
 
     ProgressReport progressReport = new ProgressReport("Report about progress of OmniSharp analyzer", TimeUnit.SECONDS.toMillis(10));
     progressReport.start(StreamSupport.stream(context.fileSystem().inputFiles(predicate).spliterator(), false).map(InputFile::toString).collect(Collectors.toList()));
@@ -137,7 +139,7 @@ public class OmnisharpSensor implements Sensor {
           cancelled = true;
           break;
         }
-        scanFile(context, inputFile);
+        scanFile(context, inputFilesByPath, inputFile);
         progressReport.nextFile();
       }
       successfullyCompleted = !cancelled;
@@ -169,7 +171,7 @@ public class OmnisharpSensor implements Sensor {
     return config;
   }
 
-  private void scanFile(SensorContext context, InputFile f) {
+  private void scanFile(SensorContext context, Map<Path, InputFile> inputFilesByPath, InputFile f) {
     String buffer;
     try {
       buffer = f.contents();
@@ -177,41 +179,41 @@ public class OmnisharpSensor implements Sensor {
       throw new IllegalStateException("Unable to read file buffer", e);
     }
     omnisharpEndpoints.updateBuffer(f.file(), buffer);
-    omnisharpEndpoints.codeCheck(f.file(), diag -> handle(context, diag));
+    omnisharpEndpoints.codeCheck(f.file(), diag -> handle(context, inputFilesByPath, diag));
   }
 
-  private static void handle(SensorContext context, Diagnostic diag) {
+  private static void handle(SensorContext context, Map<Path, InputFile> inputFilesByPath, Diagnostic diag) {
     var ruleKey = RuleKey.of(OmnisharpPluginConstants.REPOSITORY_KEY, diag.getId());
     if (context.activeRules().find(ruleKey) != null) {
       var diagFilePath = Paths.get(diag.getFilename());
-      var diagInputFile = findInputFile(context, diagFilePath);
+      var diagInputFile = findInputFile(inputFilesByPath, diagFilePath);
       if (diagInputFile != null) {
         var newIssue = context.newIssue();
         newIssue
           .forRule(ruleKey)
           .at(createLocation(newIssue, diag, diagInputFile));
-        handleSecondaryLocations(context, diag, newIssue);
-        handleQuickFixes(context, diag, newIssue);
+        handleSecondaryLocations(inputFilesByPath, diag, newIssue);
+        handleQuickFixes(inputFilesByPath, diag, newIssue);
         newIssue.save();
       }
     }
   }
 
-  private static void handleQuickFixes(SensorContext context, Diagnostic diag, NewIssue newIssue) {
+  private static void handleQuickFixes(Map<Path, InputFile> inputFilesByPath, Diagnostic diag, NewIssue newIssue) {
     var quickFixes = diag.getQuickFixes();
     if (quickFixes != null && quickFixes.length > 0) {
       newIssue.setQuickFixAvailable(true);
       for (var quickFix : quickFixes) {
-        handleQuickFix(context, quickFix, newIssue);
+        handleQuickFix(inputFilesByPath, quickFix, newIssue);
       }
     }
   }
 
-  static void handleQuickFix(SensorContext context, QuickFix quickFix, NewIssue newIssue) {
+  static void handleQuickFix(Map<Path, InputFile> inputFilesByPath, QuickFix quickFix, NewIssue newIssue) {
     var newQuickFix = newIssue.newQuickFix();
     newQuickFix.message(quickFix.getMessage());
     for (Fix fix : quickFix.getFixes()) {
-      var fixInputFile = findInputFile(context, Paths.get(fix.getFilename()));
+      var fixInputFile = findInputFile(inputFilesByPath, Paths.get(fix.getFilename()));
       if (fixInputFile != null) {
         var newInputFileEdit = newQuickFix.newInputFileEdit()
           .on(fixInputFile);
@@ -227,12 +229,12 @@ public class OmnisharpSensor implements Sensor {
     newIssue.addQuickFix(newQuickFix);
   }
 
-  private static void handleSecondaryLocations(SensorContext context, Diagnostic diag, NewIssue newIssue) {
+  private static void handleSecondaryLocations(Map<Path, InputFile> inputFilesByPath, Diagnostic diag, NewIssue newIssue) {
     var additionalLocations = diag.getAdditionalLocations();
     if (additionalLocations != null) {
       for (var additionalLocation : additionalLocations) {
         var additionalFilePath = Paths.get(additionalLocation.getFilename());
-        var additionalFilePathInputFile = findInputFile(context, additionalFilePath);
+        var additionalFilePathInputFile = findInputFile(inputFilesByPath, additionalFilePath);
         if (additionalFilePathInputFile != null) {
           newIssue.addLocation(createLocation(newIssue, additionalLocation, additionalFilePathInputFile));
         }
@@ -240,12 +242,18 @@ public class OmnisharpSensor implements Sensor {
     }
   }
 
-  private static InputFile findInputFile(SensorContext context, Path filePath) {
-    var normalizedFilePath = normalizePath(filePath);
-    return StreamSupport.stream(context.fileSystem().inputFiles(context.fileSystem().predicates().all()).spliterator(), false)
-      .filter(inputFile -> normalizedFilePath.equals(normalizePath(Paths.get(inputFile.uri()))))
-      .findFirst()
-      .orElse(null);
+  private static Map<Path, InputFile> indexInputFiles(SensorContext context) {
+    Map<Path, InputFile> inputFilesByPath = new HashMap<>();
+    for (InputFile inputFile : context.fileSystem().inputFiles(context.fileSystem().predicates().all())) {
+      if ("file".equalsIgnoreCase(inputFile.uri().getScheme())) {
+        inputFilesByPath.putIfAbsent(normalizePath(Paths.get(inputFile.uri())), inputFile);
+      }
+    }
+    return inputFilesByPath;
+  }
+
+  private static InputFile findInputFile(Map<Path, InputFile> inputFilesByPath, Path filePath) {
+    return inputFilesByPath.get(normalizePath(filePath));
   }
 
   private static Path normalizePath(Path path) {

--- a/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/OmnisharpSensorTests.java
+++ b/omnisharp-plugin/src/test/java/org/sonarsource/sonarlint/omnisharp/OmnisharpSensorTests.java
@@ -151,11 +151,12 @@ class OmnisharpSensorTests {
     SensorContextTester sensorContext = SensorContextTester.create(baseDir);
     sensorContext.settings().appendProperty(CSharpPropertyDefinitions.getAnalyzerPath(), OmnisharpTestUtils.ANALYZER_JAR.toString());
 
-    Path filePath = baseDir.resolve("Foo.cs");
+    Path filePath = baseDir.resolve("diretório").resolve("TipoPrestaçãoColeção.cs");
+    Files.createDirectories(filePath.getParent());
     String content = "Console.WriteLine(\"Hello World!\");";
     Files.write(filePath, content.getBytes(StandardCharsets.UTF_8));
 
-    InputFile file = TestInputFileBuilder.create("", "Foo.cs")
+    InputFile file = TestInputFileBuilder.create("", "diretório/TipoPrestaçãoColeção.cs")
       .setModuleBaseDir(baseDir)
       .setLanguage(OmnisharpPluginConstants.LANGUAGE_KEY)
       .setCharset(StandardCharsets.UTF_8)
@@ -338,17 +339,20 @@ class OmnisharpSensorTests {
     RuleKey ruleKey = RuleKey.of(OmnisharpPluginConstants.REPOSITORY_KEY, "S12345");
     sensorContext.setActiveRules(new ActiveRulesBuilder().addRule(new NewActiveRule.Builder().setRuleKey(ruleKey).build()).build());
 
-    Path filePath = baseDir.resolve("Foo.cs");
+    Path filePath = baseDir.resolve("diretório").resolve("TipoPrestaçãoColeção.cs");
+    Files.createDirectories(filePath.getParent());
     String content = "Console.WriteLine(\"Hello World!\");";
     Files.write(filePath, content.getBytes(StandardCharsets.UTF_8));
 
-    InputFile file = TestInputFileBuilder.create("", "Foo.cs")
+    InputFile file = TestInputFileBuilder.create("", "diretório/TipoPrestaçãoColeção.cs")
       .setModuleBaseDir(baseDir)
       .setLanguage(OmnisharpPluginConstants.LANGUAGE_KEY)
       .setCharset(StandardCharsets.UTF_8)
       .initMetadata(content)
       .build();
     sensorContext.fileSystem().add(file);
+
+    assertThat(file.uri().toASCIIString()).contains("diret%C3%B3rio/TipoPresta%C3%A7%C3%A3oCole%C3%A7%C3%A3o.cs");
 
     ArgumentCaptor<Consumer<Diagnostic>> captor = ArgumentCaptor.forClass(Consumer.class);
 


### PR DESCRIPTION
## Summary

Fixes the OmniSharp-to-InputFile path correlation for Windows paths containing Unicode characters.

## Root cause

The sensor compared OmniSharp's native Windows path against the engine file representation indirectly. Input files are represented by percent-encoded file URIs, causing diagnostics for accented paths to be dropped before RPC publication.

## Changes

- Match files by converting each `InputFile` URI through `Paths.get(URI)`.
- Normalize absolute paths and Unicode NFC before comparison.
- Add unit and end-to-end coverage for `diretório/TipoPrestaçãoColeção.cs`.

## Validation

- `OmnisharpSensorTests` — 13 tests passed.
- `OmnisharpIntegrationTests#analyzeCSharpFileWithUnicodePath` — passed.
- `mvn -DskipIts -DskipTests package` — passed.